### PR TITLE
Increase allocation precision

### DIFF
--- a/contracts/IAO.sol
+++ b/contracts/IAO.sol
@@ -191,7 +191,7 @@ contract IAO is ReentrancyGuard, Initializable {
         // 1e6 = 100%
         // 1e4 = 1%
         // 1 = 0.0001%
-        return (userInfo[_user].amount * 1e12 / totalAmount) / 1e6;
+        return (userInfo[_user].amount * 1e12 / totalAmount);
     }
 
     function getTotalStakeTokenBalance() public view returns (uint256) {
@@ -209,7 +209,7 @@ contract IAO is ReentrancyGuard, Initializable {
     /// @param _user Address of the user allocation to look up
     function getOfferingAmount(address _user) public view returns (uint256) {
         if (totalAmount > raisingAmount) {
-            return (offeringAmount * getUserAllocation(_user)) / 1e6;
+            return (offeringAmount * getUserAllocation(_user)) / 1e12;
         } else {
             // Return an offering amount equal to a proportion of the raising amount
             return (userInfo[_user].amount * offeringAmount) / raisingAmount;
@@ -230,7 +230,7 @@ contract IAO is ReentrancyGuard, Initializable {
         if (totalAmount <= raisingAmount || userInfo[_user].refunded == true) {
             return 0;
         }
-        uint256 payAmount = (raisingAmount * getUserAllocation(_user)) / 1e6;
+        uint256 payAmount = (raisingAmount * getUserAllocation(_user)) / 1e12;
         return userInfo[_user].amount - payAmount;
     }
 

--- a/test/IAO.test.js
+++ b/test/IAO.test.js
@@ -15,8 +15,8 @@ describe('IAO', function() {
 
   const [minter, dev, alice, bob, carol] = accounts;
   beforeEach(async () => {
-    this.raisingToken = await MockERC20.new('LPToken', 'LP1', ether(RAISING_AMOUNT + '000000'), { from: minter });
-    this.offeringToken = await MockERC20.new('WOW', 'WOW', ether(OFFERING_AMOUNT + '000000'), { from: minter });
+    this.raisingToken = await MockERC20.new('LPToken', 'LP1', ether(RAISING_AMOUNT + '000000000000'), { from: minter });
+    this.offeringToken = await MockERC20.new('WOW', 'WOW', ether(OFFERING_AMOUNT + '000000000000'), { from: minter });
 
     await this.raisingToken.transfer(bob, ether(RAISING_AMOUNT), { from: minter });
     await this.raisingToken.transfer(alice, ether(RAISING_AMOUNT), { from: minter });
@@ -61,8 +61,8 @@ describe('IAO', function() {
     await this.iao.deposit(ether('200'), {from: alice});
     await this.iao.deposit(ether('300'), {from: carol});
     assert.equal((await this.iao.totalAmount()).toString(), ether('600'));
-    assert.equal((await this.iao.getUserAllocation(carol)).toString(), '500000');
-    assert.equal((await this.iao.getUserAllocation(alice)).toString(), '333333');
+    assert.equal((await this.iao.getUserAllocation(carol)).toString(), '500000000000');
+    assert.equal((await this.iao.getUserAllocation(alice)).toString(), '333333333333');
     assert.equal((await this.iao.getOfferingAmount(carol)).toString(), ether('30000000'));
     assert.equal((await this.iao.getOfferingAmount(bob)).toString(), ether('10000000'));
     assert.equal((await this.iao.getRefundingAmount(bob)).toString(), ether('0'));
@@ -172,13 +172,13 @@ describe('IAO', function() {
     await this.iao.deposit(ether('200'), {from: alice});
     await this.iao.deposit(ether('300'), {from: carol});
     assert.equal((await this.iao.totalAmount()).toString(), ether('1800'));
-    assert.equal((await this.iao.getUserAllocation(carol)).toString(), '500000');
-    assert.equal((await this.iao.getUserAllocation(alice)).toString(), '333333');
+    assert.equal((await this.iao.getUserAllocation(carol)).toString(), '500000000000');
+    assert.equal((await this.iao.getUserAllocation(alice)).toString(), '333333333333');
     assert.equal((await this.iao.getOfferingAmount(carol)).toString(), ether('50000000'));
-    assert.equal((await this.iao.getOfferingAmount(bob)).toString(), ether('16666600'));
-    assert.equal((await this.iao.getOfferingAmount(alice)).toString(), ether('33333300'));
+    assert.equal((await this.iao.getOfferingAmount(bob)).toString(), ether('16666666.6666'));
+    assert.equal((await this.iao.getOfferingAmount(alice)).toString(), ether('33333333.3333'));
     assert.equal((await this.iao.getRefundingAmount(carol)).toString(), ether('400'));
-    assert.equal((await this.iao.getRefundingAmount(bob)).toString(), ether('133.334'));
+    assert.equal((await this.iao.getRefundingAmount(bob)).toString(), ether('133.333333334'));
     await expectRevert(
       this.iao.harvest(0, {from: bob}),
       'not harvest time',
@@ -235,12 +235,12 @@ describe('IAO', function() {
     }
 
     // 100 offering tokens are left due to rounding 
-    assert.equal((await this.offeringToken.balanceOf(this.iao.address)).toString(), ether('100'));
-    assert.equal((await this.raisingToken.balanceOf(this.iao.address)).toString(), ether('999.999'));
+    assert.equal((await this.offeringToken.balanceOf(this.iao.address)).toString(), ether('.0001'));
+    assert.equal((await this.raisingToken.balanceOf(this.iao.address)).toString(), ether('999.999999999'));
     // final withdraw
-    await this.iao.finalWithdraw(ether('999.999'), ether('100'), {from: dev})
-    assert.equal((await this.offeringToken.balanceOf(dev)).toString(), ether('100'));
-    assert.equal((await this.raisingToken.balanceOf(dev)).toString(), ether('999.999'));
+    await this.iao.finalWithdraw(ether('999.999999999'), ether('.0001'), {from: dev})
+    assert.equal((await this.offeringToken.balanceOf(dev)).toString(), ether('.0001'));
+    assert.equal((await this.raisingToken.balanceOf(dev)).toString(), ether('999.999999999'));
     assert.equal((await this.offeringToken.balanceOf(this.iao.address)).toString(), ether('0'));
     assert.equal((await this.raisingToken.balanceOf(this.iao.address)).toString(), ether('0'));
 
@@ -288,8 +288,8 @@ describe('IAO', function() {
     await this.iao.deposit(ether('2'), {from: alice});
     await this.iao.deposit(ether('3'), {from: carol});
     assert.equal((await this.iao.totalAmount()).toString(), ether('18'));
-    assert.equal((await this.iao.getUserAllocation(carol)).toString(), '500000');
-    assert.equal((await this.iao.getUserAllocation(alice)).toString(), '333333');
+    assert.equal((await this.iao.getUserAllocation(carol)).toString(), '500000000000');
+    assert.equal((await this.iao.getUserAllocation(alice)).toString(), '333333333333');
     assert.equal((await this.iao.getOfferingAmount(carol)).toString(), ether('9'));
     assert.equal((await this.iao.getOfferingAmount(minter)).toString(), ether('0'));
     assert.equal((await this.iao.getOfferingAmount(bob)).toString(), ether('3'));
@@ -376,7 +376,7 @@ describe('IAO', function() {
   })
 
   it('should handle allocations <1/1e6 when enough++ lp is raised', async () => {
-    const BIG_RAISING_AMOUNT = '1000000';
+    const BIG_RAISING_AMOUNT = '1000000000';
     await this.raisingToken.transfer(bob, ether(BIG_RAISING_AMOUNT), { from: minter });
     await this.raisingToken.transfer(alice, ether(BIG_RAISING_AMOUNT), { from: minter });
     await this.raisingToken.transfer(carol, ether(BIG_RAISING_AMOUNT), { from: minter });
@@ -386,7 +386,7 @@ describe('IAO', function() {
     await this.iao.initialize(
       this.raisingToken.address, 
       this.offeringToken.address, 
-      '400', 
+      '500', 
       '50',
       '10',
       ether(OFFERING_AMOUNT), // offering amount 
@@ -395,10 +395,10 @@ describe('IAO', function() {
       { from: minter }
     );
 
-    assert.equal((await this.iao.harvestReleaseBlocks(0)).toString(), '450');
-    assert.equal((await this.iao.harvestReleaseBlocks(1)).toString(), '460');
-    assert.equal((await this.iao.harvestReleaseBlocks(2)).toString(), '470');
-    assert.equal((await this.iao.harvestReleaseBlocks(3)).toString(), '480');
+    assert.equal((await this.iao.harvestReleaseBlocks(0)).toString(), '550');
+    assert.equal((await this.iao.harvestReleaseBlocks(1)).toString(), '560');
+    assert.equal((await this.iao.harvestReleaseBlocks(2)).toString(), '570');
+    assert.equal((await this.iao.harvestReleaseBlocks(3)).toString(), '580');
 
 
     await this.offeringToken.transfer(this.iao.address, ether(OFFERING_AMOUNT), { from: minter });
@@ -411,7 +411,7 @@ describe('IAO', function() {
       'not iao time',
     );
 
-    await time.advanceBlockTo('400');
+    await time.advanceBlockTo('500');
 
     await this.iao.deposit(ether(BIG_RAISING_AMOUNT), {from: bob});
     await this.iao.deposit(ether(BIG_RAISING_AMOUNT), {from: alice});
@@ -419,17 +419,18 @@ describe('IAO', function() {
     await this.iao.deposit(ether('1'), {from: carol}); // Low deposit
     // check allocations
     assert.equal((await this.iao.totalAmount()).toString(), ether(BIG_RAISING_AMOUNT).add(ether(BIG_RAISING_AMOUNT)).add(ether('1')));
-    assert.equal((await this.iao.getUserAllocation(alice)).toString(), '499999');
-    assert.equal((await this.iao.getUserAllocation(bob)).toString(), '499999');
-    assert.equal((await this.iao.getUserAllocation(carol)).toString(), '0');
+    assert.equal((await this.iao.getUserAllocation(alice)).toString(), '499999999750');
+    assert.equal((await this.iao.getUserAllocation(bob)).toString(), '499999999750');
+    assert.equal((await this.iao.getUserAllocation(carol)).toString(), '499');
     // check offering amounts
-    assert.equal((await this.iao.getOfferingAmount(alice)).toString(), ether('49999900'));
-    assert.equal((await this.iao.getOfferingAmount(bob)).toString(), ether('49999900'));
-    assert.equal((await this.iao.getOfferingAmount(carol)).toString(), ether('0'));
+    
+    assert.equal((await this.iao.getOfferingAmount(alice)).toString(), ether('49999999.975'));
+    assert.equal((await this.iao.getOfferingAmount(bob)).toString(), ether('49999999.975'));
+    assert.equal((await this.iao.getOfferingAmount(carol)).toString(), ether('.0499'));
     // check refunding amount
-    assert.equal((await this.iao.getRefundingAmount(alice)).toString(), ether('500001'));
-    assert.equal((await this.iao.getRefundingAmount(bob)).toString(), ether('500001'));
-    assert.equal((await this.iao.getRefundingAmount(carol)).toString(), ether('1'));
+    assert.equal((await this.iao.getRefundingAmount(alice)).toString(), ether('500000000.250'));
+    assert.equal((await this.iao.getRefundingAmount(bob)).toString(), ether('500000000.250'));
+    assert.equal((await this.iao.getRefundingAmount(carol)).toString(), ether('.501'));
     await expectRevert(
       this.iao.harvest(0, {from: bob}),
       'not harvest time',
@@ -473,14 +474,13 @@ describe('IAO', function() {
     }
 
     // 200 offering tokens are left due to rounding 
-    assert.equal((await this.offeringToken.balanceOf(this.iao.address)).toString(), ether('200'));
-    assert.equal((await this.raisingToken.balanceOf(this.iao.address)).toString(), ether('999998'));
+    assert.equal((await this.offeringToken.balanceOf(this.iao.address)).toString(), ether('.0001'));
+    assert.equal((await this.raisingToken.balanceOf(this.iao.address)).toString(), ether('999999999.999'));
     // final withdraw
-    await this.iao.finalWithdraw(ether('999998'), ether('200'), {from: dev})
-    assert.equal((await this.offeringToken.balanceOf(dev)).toString(), ether('200'));
-    assert.equal((await this.raisingToken.balanceOf(dev)).toString(), ether('999998'));
+    await this.iao.finalWithdraw(ether('999999999.999'), ether('.0001'), {from: dev})
+    assert.equal((await this.offeringToken.balanceOf(dev)).toString(), ether('.0001'));
+    assert.equal((await this.raisingToken.balanceOf(dev)).toString(), ether('999999999.999'));
     assert.equal((await this.offeringToken.balanceOf(this.iao.address)).toString(), ether('0'));
     assert.equal((await this.raisingToken.balanceOf(this.iao.address)).toString(), ether('0'));
-
   })
 });

--- a/test/IAO.test.js
+++ b/test/IAO.test.js
@@ -473,7 +473,7 @@ describe('IAO', function() {
       assert.equal((await this.iao.hasHarvested(alice, harvestPeriod)).toString(), 'true');
     }
 
-    // 200 offering tokens are left due to rounding 
+    // offering tokens left due to rounding 
     assert.equal((await this.offeringToken.balanceOf(this.iao.address)).toString(), ether('.0001'));
     assert.equal((await this.raisingToken.balanceOf(this.iao.address)).toString(), ether('999999999.999'));
     // final withdraw


### PR DESCRIPTION
Before this update, the allocation precision was limited to 1e6, which means that if you deposited less than 1/1e6 of the total deposited amount then you would receive no allocation. 

With this update, now the precision is 1e12, which means users will get an allocation as long as they have more than 1 trillionth of the total deposits. 

- Added a test to check for deposits with less than 1/1e6 of the total deposits