### PR TITLE
Skip `finalWithdraw` transfers if 0 amount is passed

### DIFF
--- a/contracts/IAO.sol
+++ b/contracts/IAO.sol
@@ -297,12 +297,14 @@ contract IAO is ReentrancyGuardUpgradeable {
         external
         onlyAdmin
     {
-        require(
-            _offerAmount <= offeringToken.balanceOf(address(this)),
-            "not enough offering token"
-        );
         safeTransferStakeInternal(msg.sender, _stakeTokenAmount);
-        offeringToken.safeTransfer(msg.sender, _offerAmount);
+        if(_offerAmount > 0) {
+            require(
+                _offerAmount <= offeringToken.balanceOf(address(this)),
+                "not enough offering token"
+            );
+            offeringToken.safeTransfer(msg.sender, _offerAmount);
+        }
         emit AdminFinalWithdraw(_stakeTokenAmount, _offerAmount);
     }
 
@@ -311,6 +313,7 @@ contract IAO is ReentrancyGuardUpgradeable {
     /// @param _to address to send stake token to 
     /// @param _amount value of reward token to transfer
     function safeTransferStakeInternal(address _to, uint256 _amount) internal {
+        if(_amount == 0) { return; }
         require(
             _amount <= getTotalStakeTokenBalance(),
             "not enough stake token"

--- a/contracts/IAOLinearVesting.sol
+++ b/contracts/IAOLinearVesting.sol
@@ -346,12 +346,14 @@ contract IAOLinearVesting is ReentrancyGuardUpgradeable {
         external
         onlyAdmin
     {
-        require(
-            _offerAmount <= offeringToken.balanceOf(address(this)),
-            "not enough offering token"
-        );
         safeTransferStakeInternal(msg.sender, _stakeTokenAmount);
-        offeringToken.safeTransfer(msg.sender, _offerAmount);
+        if(_offerAmount > 0) {
+            require(
+                _offerAmount <= offeringToken.balanceOf(address(this)),
+                "not enough offering token"
+            );
+            offeringToken.safeTransfer(msg.sender, _offerAmount);
+        }
         emit AdminFinalWithdraw(_stakeTokenAmount, _offerAmount);
     }
 
@@ -360,6 +362,7 @@ contract IAOLinearVesting is ReentrancyGuardUpgradeable {
     /// @param _to address to send stake token to 
     /// @param _amount value of reward token to transfer
     function safeTransferStakeInternal(address _to, uint256 _amount) internal {
+        if(_amount == 0) { return; }
         require(
             _amount <= getTotalStakeTokenBalance(),
             "not enough stake token"


### PR DESCRIPTION
A reverting call was experienced when trying to remove `stakeToken`s and zero `offeringTokens`. The call went through when removing 1 wei worth of `offeringTokens`. This update will skip the transfers if the amount passed is zero.

<img width="1135" alt="Screen Shot 2022-09-07 at 7 59 26 AM" src="https://user-images.githubusercontent.com/78645267/188873799-5e956830-a796-4a2f-a0a0-30475bfa6a84.png">


